### PR TITLE
Ubuntu now prefers apt

### DIFF
--- a/purebuntu.py
+++ b/purebuntu.py
@@ -47,10 +47,10 @@ def main():
       removalmetapackage=args.remove
       keptmetapackage=args.keep         
       removalitems=getitemstoremove(getdependencies(removalmetapackage), getdependencies(keptmetapackage))
-      print("\nsudo apt-get remove", end=" ")
+      print("\nsudo apt remove", end=" ")
       for removalitem in removalitems:
          print(removalitem, end=" ")
-      print("&& sudo apt-get install %s" % keptmetapackage, end="\n")
+      print("&& sudo apt install %s" % keptmetapackage, end="\n")
    else:
       print("You need to specify a metapackage to --keep and a metapackage to --remove. Run pureubuntu.py -h for more details.", end="\n")
 


### PR DESCRIPTION
Since Ubuntu 16.04, Ubuntu now prefers using the shorter apt commands instead of apt-get. https://www.maketecheasier.com/apt-vs-apt-get-ubuntu/

This changes the output to use the new commands.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aysiu/purebuntu/3)
<!-- Reviewable:end -->
